### PR TITLE
Removed groovy meta declation

### DIFF
--- a/jointcalling.nf
+++ b/jointcalling.nf
@@ -1,8 +1,5 @@
 #!/usr/bin/env nextflow
 /*
-vim: syntax=groovy
--*- mode: groovy;-*-
- *
  * Developed by the Genome Institute of Singapore for
  * SG10K health / the National Precision Medicine Program Singapore
  *

--- a/main.nf
+++ b/main.nf
@@ -1,8 +1,5 @@
 #!/usr/bin/env nextflow
 /*
- * vim: syntax=groovy
- * -*- mode: groovy;-*-
- *
  * Developed by the Genome Institute of Singapore for
  * SG10K health / the National Precision Medicine Program Singapore
  *


### PR DESCRIPTION
The groovy lang meta declaration prevents to correct Nextflow syntax 
highlighting on GitHub and editors such as VS Code and Atom.